### PR TITLE
fix(studio): Ensure null-termination of layer name read from settings

### DIFF
--- a/app/src/keymap.c
+++ b/app/src/keymap.c
@@ -791,12 +791,14 @@ static int keymap_handle_set(const char *name, size_t len, settings_read_cb read
             LOG_WRN("Found layer name for invalid layer ID %d", layer);
         }
 
-        int err = read_cb(cb_arg, zmk_keymap_layer_names[layer],
+        int ret = read_cb(cb_arg, zmk_keymap_layer_names[layer],
                           MIN(len, CONFIG_ZMK_KEYMAP_LAYER_NAME_MAX_LEN - 1));
-        if (err <= 0) {
-            LOG_ERR("Failed to handle keymap layer name from settings (err %d)", err);
-            return err;
+        if (ret <= 0) {
+            LOG_ERR("Failed to handle keymap layer name from settings (err %d)", ret);
+            return ret;
         }
+
+        zmk_keymap_layer_names[layer][ret] = 0;
     } else if (settings_name_steq(name, "l", &next) && next) {
         char *endptr;
         uint8_t layer = strtoul(next, &endptr, 10);


### PR DESCRIPTION
This fixes the string leak when a layer name is changed to a longer one, but is discarded and reverted to the original shorter one from ZMK Studio.

<!-- If you're adding a board/shield please fill out this check-list, otherwise you can delete it -->

## Board/Shield Check-list

- [ ] This board/shield is tested working on real hardware
- [ ] Definitions follow the general style of other shields/boards upstream ([Reference](https://zmk.dev/docs/development/new-shield))
- [ ] `.zmk.yml` metadata file added
- [ ] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [ ] General consistent formatting of DeviceTree files
- [ ] Keymaps do not use deprecated key defines (Check using the [upgrader tool](https://zmk.dev/docs/codes/keymap-upgrader))
- [ ] `&pro_micro` used in favor of `&pro_micro_d/a` if applicable
- [ ] If split, no name added for the right/peripheral half
- [ ] Kconfig.defconfig file correctly wraps _all_ configuration in conditional on the shield symbol
- [ ] `.conf` file has optional extra features commented out
- [ ] Keyboard/PCB is part of a shipped group buy or is generally available in stock to purchase (OSH/personal projects without general availability should create a zmk-config repo instead)
